### PR TITLE
Gracefully handles when draft_choices is not cut enough

### DIFF
--- a/DraftRetriever/src/lib.rs
+++ b/DraftRetriever/src/lib.rs
@@ -353,6 +353,11 @@ impl Reader {
 
         let (draft_choices, max_branch) = get_draft_choices(paths.clone());
 
+        if draft_choices.len() > choices as usize {
+            // It might not be cut enough because cut_to_choices() is best effort, as mentioned in the comment above
+            return Err(exceptions::PyValueError::new_err("draft_choices was not cut enough"));
+        }
+
         let (draft_attn_mask, tree_indices, draft_position_ids, retrieve_indices) = generate_draft_buffers(draft_choices.clone(), max_branch);
 
         let max_length = paths.iter().map(|path| path.len()).max().unwrap_or(0);


### PR DESCRIPTION
In `lib.rs`, `cut_to_choices()` is "best effort" in cutting a tree down to have <= `choices` number of tokens. Empirically, when `choices=64`, it fails to cut the tree down about 1 in a million times. I made this change so that the error that occurs when this happens is much easier to track down. I did not make any upstream changes to catching this error in `gen_model_answer_rest.py` because I think it's best to crash when this happens in that specific use case. However, in other situations (e.g. querying REST 100 million times to gather statistics about it), it is better to catch and ignore this error. The change in this PR simply allows developers to choose how they want to catch this error when using the `DraftReceiver` wheel instead of having it always crash when `cut_to_choices()` fails.